### PR TITLE
Fix parse_money's memmem pointer

### DIFF
--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -1064,9 +1064,9 @@ static size_t parse_money(struct libinjection_sqli_state *sf)
             }
 
             /* we have $foobar$ ... find it again */
-            strend = my_memmem(cs+xlen+2, slen - (pos+xlen+2), cs + pos, xlen+2);
+            strend = my_memmem(cs+pos+xlen+2, slen - (pos+xlen+2), cs + pos, xlen+2);
 
-            if (strend == NULL || ((size_t)(strend - cs) < (pos+xlen+2))) {
+            if (strend == NULL) {
                 /* fell off edge */
                 st_assign(sf->current, TYPE_STRING, pos+xlen+2, slen - pos - xlen - 2, cs+pos+xlen+2);
                 sf->current->str_open = '$';


### PR DESCRIPTION
Original PR from @wenchuan:

```
Pass the correct pointer to memmem()

In parse_money(), if there is a "$foobar$", it calls memmem() to find it
again. Wrong pointer can cause itself to backtrack in a dead loop and hang
the entire process.
```
https://github.com/client9/libinjection/pull/131