### PR TITLE
Makefile: use CC, LD and AR from environment if available

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,10 @@
 
-AR=ar -r
+AR ?= ar
 # MAC
 # AR=libtool -static
 
-CC=cc
-LD=ld
+CC ?= cc
+LD ?= ld
 CFLAGS=-Wall -Wextra -Werror -pedantic -ansi -g -O3 -fPIC
 
 INSTALL=install
@@ -67,7 +67,7 @@ ${SHAREDLIB}: ${OBJECTS}
 
 ${STATICLIB}: ${OBJECTS}
 	rm -f ${STATICLIB}
-	${AR} ${STATICLIB} ${OBJECTS}
+	${AR} -r ${STATICLIB} ${OBJECTS}
 
 check: ${TESTDRIVERS}
 	@./test-driver.sh test-unit.sh


### PR DESCRIPTION
Hello,

I'm building this dependency through the https://github.com/sysown/proxysql project which bundles your project. I'm currently packaging proxysql and the distribution I use (Exherbo) forbids using classic `cc`, `ld` or `ar` executables to instead use prefixed binaries to ease the cross-compilation, for example: `x86_64-pc-linux-gnu-cc`. Those are exported in `CC`, `LD` or `AR` environment variables and picked up by `make`.

My patch ease the use of those tools by not hardcoding them or having to explicitly pass them as arguments to `make`. I also moved the `-r` flag of `ar` where `${AR}` is used to avoid having to define the `-r` flag in the environment variable.

Let me know what you think of this.