### PR TITLE
Makefile: Use CFLAGS if provided

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ AR ?= ar
 
 CC ?= cc
 LD ?= ld
-CFLAGS=-Wall -Wextra -Werror -pedantic -ansi -g -O3 -fPIC
+CFLAGS ?= -Wall -Wextra -Werror -pedantic -ansi -g -O3 -fPIC
 
 INSTALL=install
 PREFIX=/usr/local


### PR DESCRIPTION
A user may need to provide custom CFLAGS, for example to pass a custom sysroot when compiling to WebAssembly. It would be good if the Makefile can accept custom CFLAGS.