### PR TITLE
Remove indentation from autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-    #!/bin/sh
-    set -e
-    autoreconf -i --force
-    rm -rf autom4te.cache
+#!/bin/sh
+set -e
+autoreconf -i --force
+rm -rf autom4te.cache


### PR DESCRIPTION
On some systems, in my case Debian aarch64 (amd64 is fine), leading whitespace before a shebang is not permitted and results in a build failure. The indentation in this file is unnecessary, so remove it.