### PR TITLE
Fixes a problem with deep recursion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,4 +20,4 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
 tests: all
-	@cd src && $(MAKE) $(AM_MAKEFLAGS) tests
+	@cd src && $(MAKE) $(AM_MAKEFLAGS) check

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,11 +17,12 @@ sqlparse_data.json: sqlparse_map.py fingerprints
 libinjection_sqli_data.h: sqlparse2c.py sqlparse_data.json
 	./sqlparse2c.py < sqlparse_data.json > libinjection_sqli_data.h
 
-check: reader testdriver testspeedxss testspeedsqli
+check: reader testdriver testspeedxss testspeedsqli teststackxss
 	@./test-driver.sh test-unit.sh
 	@./test-driver.sh test-samples-sqli-negative.sh
 	@./test-driver.sh test-samples-sqli-positive.sh
 	@./test-driver.sh test-samples-xss-positive.sh
+	@./test-driver.sh teststackxss
 
 analyze:
 	rm -rf /tmp/libinjection-analyze.txt
@@ -50,7 +51,7 @@ libinjection_la_SOURCES = libinjection_sqli.c libinjection_html5.c libinjection_
 
 include_HEADERS= libinjection.h libinjection_sqli.h libinjection_sqli_data.h libinjection_html5.h libinjection_xss.h
 
-noinst_PROGRAMS = html5 sqli fptool reader testdriver testspeedxss testspeedsqli
+noinst_PROGRAMS = html5 sqli fptool reader testdriver testspeedxss testspeedsqli teststackxss
 
 # Samples
 html5_SOURCES = html5_cli.c
@@ -69,3 +70,6 @@ testspeedxss_SOURCES = test_speed_xss.c
 testspeedxss_LDADD = libinjection.la
 testspeedsqli_SOURCES = test_speed_sqli.c
 testspeedsqli_LDADD = libinjection.la
+teststackxss_SOURCES = test_stack_xss.c
+teststackxss_LDADD = libinjection.la
+teststackxss_CFLAGS = -O0

--- a/src/libinjection_html5.c
+++ b/src/libinjection_html5.c
@@ -323,6 +323,10 @@ static int h5_state_before_attribute_name(h5_state_t* hs)
     int ch;
 
     TRACE();
+
+    /* for manual tail call optimization, see comment below */
+    tail_call:;
+
     ch = h5_skip_white(hs);
     switch (ch) {
     case CHAR_EOF: {
@@ -330,6 +334,18 @@ static int h5_state_before_attribute_name(h5_state_t* hs)
     }
     case CHAR_SLASH: {
         hs->pos += 1;
+        /* Logically, We want to call h5_state_self_closing_start_tag(hs) here.
+
+           As this function may call us back and the compiler
+           might not implement automatic tail call optimization,
+           this might result in a deep recursion.
+
+           We detect this case here and start over with the current state.
+        */
+
+        if (hs->pos < hs->len && hs->s[hs->pos] != CHAR_GT) {
+            goto tail_call;
+        }
         return h5_state_self_closing_start_tag(hs);
     }
     case CHAR_GT: {
@@ -574,6 +590,8 @@ static int h5_state_after_attribute_value_quoted_state(h5_state_t* hs)
 
 /**
  * 12.2.4.43
+ *
+ *  WARNING: This function is partially inlined into h5_state_before_attribute_name()
  */
 static int h5_state_self_closing_start_tag(h5_state_t* hs)
 {

--- a/src/test_stack_xss.c
+++ b/src/test_stack_xss.c
@@ -13,7 +13,7 @@
  */
 
 
-int main(int argc, const char *argv[])
+int main()
 {
     const size_t input_size = 10000000;
 

--- a/src/test_stack_xss.c
+++ b/src/test_stack_xss.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <strings.h>
+#include <assert.h>
+
+#include "libinjection.h"
+
+/*
+ * reproduce core dump due to a stack overflow in libinjection.
+ * to run this test, libinjection must be compiled without optimization
+ *
+ * gcc -O0 -o test_stack_xss src/test_stack_xss.c  src/libinjection*.c && ./test_stack_xss && echo OK
+ *
+ */
+
+
+int main(int argc, const char *argv[])
+{
+    const size_t input_size = 10000000;
+
+    char *input = malloc(input_size);
+
+    assert(input != NULL);
+
+    memset(input, '/', input_size);
+    input[input_size - 1] = '\0';
+
+    // should not crash
+    libinjection_xss(input, strlen(input));
+
+    return 0;
+}


### PR DESCRIPTION
This fixes #33 by implementing manual tail call optimization in `h5_state_before_attribute_name()`

The following calls are running without error on my machine

```
./autogen.sh && ./configure && make
./run-clang-asan.sh && ./run-gcov-samples.sh && ./run-gcov-unittests.sh
```

`./make-ci.sh` fails, because of

```
./make-ci.sh: 47: ./make-ci.sh: ./configure-clang.sh: not found
```