### PR TITLE
feat: add support for sanitizers and for fuzzing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
             --inconclusive \
             --suppress=variableScope \
             --suppress=missingInclude \
+            --suppress=unusedFunction:src/fuzz/*.c \
             --quiet \
             --error-exitcode=1 \
             --template='{file}:{line} {id} {severity} {message}' \
@@ -43,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         platform: [x32, x64]
         compiler: [gcc, clang]
     steps:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,19 @@
+name: Fuzzing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    name: fuzzing
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          ./autogen.sh
+          CC=clang CXX=clang++ ./configure --enable-sanitizers --enable-fuzzers
+          make
+      - name: fuzz
+        run: ./src/fuzz/fuzzer -max_total_time="${MAX_TOTAL_TIME:-300}" -print_pcs=1 -workers="${FUZZY_WORKERS:-0}" -jobs="${FUZZY_JOBS:-0}" ./src/fuzz/corpus 

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ stamp-h1
 
 src/.libs
 src/version.h
+src/teststackxss
+
+src/fuzz/fuzzer
+src/fuzz/corpus

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,9 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 build-aux/compile \
 		build-aux/m4/ltversion.m4 build-aux/m4/lt~obsolete.m4
 
 SUBDIRS = src
+if BUILD_FUZZTARGETS
+SUBDIRS += src/fuzz
+endif
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libinjection.pc

--- a/build-aux/m4/ax_append_link_flags.m4
+++ b/build-aux/m4/ax_append_link_flags.m4
@@ -1,0 +1,44 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_append_link_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_LINK_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the linker works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the linker's flags (LDFLAGS) is
+#   used. During the check the flag is always added to the linker's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and AX_CHECK_LINK_FLAG.
+#   Please keep this macro in sync with AX_APPEND_COMPILE_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_LINK_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_LINK_FLAG([$flag], [AX_APPEND_FLAG([$flag], [m4_default([$2], [LDFLAGS])])], [], [$3], [$4])
+done
+])dnl AX_APPEND_LINK_FLAGS

--- a/build-aux/m4/ax_check_link_flag.m4
+++ b/build-aux/m4/ax_check_link_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,19 @@ AC_ARG_ENABLE([optimize],
                               this option will not change them]),
               [], [enable_optimize=no])
 
+dnl Enable sanitizers.
+AC_ARG_ENABLE([sanitizers],
+              AS_HELP_STRING([--enable-sanitizers],
+                             [enable ASAN ans UBSAN. If CFLAGS are set,
+                              this option will not change them]),
+              [], [enable_sanitizers=no])
+
+dnl Enable fuzzers.
+AC_ARG_ENABLE([fuzzers],
+              AS_HELP_STRING([--enable-fuzzers],
+                             [enable fuzzers; you must use clang compiler]),
+              [], [enable_fuzzers=no])
+
 LT_INIT
 AC_SUBST([LIBTOOL_DEPS])
 
@@ -128,11 +141,38 @@ compiler_flags="-g -fpic -Weverything -Wno-unused-macros -Wno-padded \
                 -Wno-covered-switch-default \
                 -Wno-disabled-macro-expansion -Wno-unused-local-typedefs"
 
+###############################################################################
+# Sanitizers.
+###############################################################################
+AM_CONDITIONAL([SANITIZERS], [test x"$enable_sanitizers" = "xyes"])
+if test "$enable_sanitizers" = yes; then
+  sanitizers_flags="-fsanitize=address,undefined -fno-omit-frame-pointer"
+  sanitizers_link_flags="-fsanitize=address,undefined"
+fi
+
+###############################################################################
+# Fuzzing.
+###############################################################################
+AM_CONDITIONAL([FUZZERS], [test x"$enable_fuzzers" = "xyes"])
+if test "$enable_fuzzers" = yes; then
+  AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer],,[AC_MSG_ERROR("Fuzzing not supported by the compiler; you must use clang")])
+  LIB_FUZZING_ENGINE=-fsanitize=fuzzer
+  BUILD_FUZZTARGETS=1
+fi
+AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzzers" = "xyes"])
+AC_SUBST(BUILD_FUZZTARGETS)
+AC_SUBST(LIB_FUZZING_ENGINE)
+
 # Now that we have all flags, check them
 AS_IF([test "x${ac_cv_env_CFLAGS_set}" = "x"],
       [
-          AX_APPEND_COMPILE_FLAGS([$debug_flags $compiler_flags $optimize_flags $hardened_flags],
+          AX_APPEND_COMPILE_FLAGS([$debug_flags $compiler_flags $optimize_flags $hardened_flags $sanitizers_flags $fuzzers_flags],
           [CFLAGS], [])
+      ])
+AS_IF([test "x${ac_cv_env_LDFLAGS_set}" = "x"],
+      [
+          AX_APPEND_LINK_FLAGS([$sanitizers_link_flags],
+          [LDFLAGS], [])
       ])
 
 if test x$use_gcov = xyes; then
@@ -155,6 +195,7 @@ fi
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile
+	src/fuzz/Makefile
     src/version.h
     libinjection.pc
 ])

--- a/make-ci.sh
+++ b/make-ci.sh
@@ -63,6 +63,7 @@ cppcheck --std=c89 \
          --inconclusive \
          --suppress=variableScope \
          --suppress=missingIncludeSystem \
+         --suppress=unusedFunction:src/fuzz/*.c \
          --quiet \
          --error-exitcode=1 \
          --template='{file}:{line} {id} {severity} {message}' \

--- a/run-fuzzers.sh
+++ b/run-fuzzers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Run fuzzer(s)
+#
+./autogen.sh
+CC=clang CXX=clang++ ./configure --enable-sanitizers --enable-fuzzers
+make
+./src/fuzz/fuzzer -max_total_time="${MAX_TOTAL_TIME:-300}" -print_pcs=1 -workers="${FUZZY_WORKERS:-0}" -jobs="${FUZZY_JOBS:-0}" ./src/fuzz/corpus

--- a/src/fuzz/Makefile.am
+++ b/src/fuzz/Makefile.am
@@ -1,0 +1,18 @@
+bin_PROGRAMS = fuzzer
+
+fuzzer_SOURCES = fuzzer.c
+fuzzer_CFLAGS = $(CXXFLAGS) $(LIB_FUZZING_ENGINE)
+fuzzer_LDADD = ../.libs/libinjection.a
+fuzzer_LDFLAGS = $(LIB_FUZZING_ENGINE)
+# force usage of CXX for linker
+fuzzer_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzzer_LDFLAGS) $(LDFLAGS) -o $@
+
+corpus:
+	./create_seed_corpus.sh corpus
+
+clean-local:
+	@rm -rf corpus
+
+all: corpus

--- a/src/fuzz/create_seed_corpus.sh
+++ b/src/fuzz/create_seed_corpus.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#Use the same input string of *all* the tests
+
+CORPUS_DIR=$1
+
+rm -f ${CORPUS_DIR}/*
+mkdir -p ${CORPUS_DIR}
+
+i=0
+for filename in ../../tests/*.txt; do
+    [ -e "$filename" ] || continue
+    sed -n '4p' < "$filename" > ${CORPUS_DIR}/"$i"
+    i=$((i + 1))
+done

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -1,0 +1,26 @@
+#include <stdlib.h>
+
+#include "../libinjection.h"
+#include "../libinjection_xss.h"
+#include "../libinjection_sqli.h"
+
+int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
+
+int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size) {
+  char *query;
+  char fingerprint[8];
+
+  /* Libinjection wants null-terminated string */
+
+  query = malloc(size + 1);
+  memcpy(query, data, size);
+  query[size] = '\0';
+
+  libinjection_sqli(query, strlen(query), fingerprint);
+
+  libinjection_xss(query, strlen(query));
+
+  free(query);
+
+  return 0;
+}

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -1282,7 +1282,7 @@ void libinjection_sqli_init(struct libinjection_sqli_state * sf, const char *s, 
 void libinjection_sqli_reset(struct libinjection_sqli_state * sf, int flags)
 {
     void *userdata = sf->userdata;
-    ptr_lookup_fn lookup = sf->lookup;;
+    ptr_lookup_fn lookup = sf->lookup;
 
     if (flags == 0) {
         flags = FLAG_QUOTE_NONE | FLAG_SQL_ANSI;

--- a/src/sqli_cli.c
+++ b/src/sqli_cli.c
@@ -62,7 +62,7 @@ void print_token(stoken_t *t) {
     printf("%s", "\n");
 }
 
-void usage() {
+void usage(void) {
     printf("\n");
     printf("libinjection sqli tester\n");
     printf("\n");

--- a/src/test_speed_sqli.c
+++ b/src/test_speed_sqli.c
@@ -49,7 +49,7 @@ int testIsSQL(void)
     return tps;
 }
 
-int main()
+int main(void)
 {
     const int mintps = 450000;
     int tps = testIsSQL();

--- a/src/test_speed_xss.c
+++ b/src/test_speed_xss.c
@@ -65,7 +65,7 @@ int testIsSQL(void)
     return tps;
 }
 
-int main()
+int main(void)
 {
     const int mintps = 500000;
     int tps = testIsSQL();

--- a/src/test_stack_xss.c
+++ b/src/test_stack_xss.c
@@ -13,7 +13,7 @@
  */
 
 
-int main()
+int main(void)
 {
     const size_t input_size = 10000000;
 


### PR DESCRIPTION
As initial seed corpus use the input strings of all the internal tests;
create it at runtime, when needed.
    
Integrate fuzzing into GitHub CI.

ubuntu-18.04 is deprecated in GitHub CI: use 20.04 and 22.0
