### PR TITLE
fix: update null terminated strings comment and fuzzer code

### DIFF
--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -7,20 +7,11 @@
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size) {
-  char *query;
   char fingerprint[8];
 
-  /* Libinjection wants null-terminated string */
+  libinjection_sqli((const char *)data, size, fingerprint);
 
-  query = malloc(size + 1);
-  memcpy(query, data, size);
-  query[size] = '\0';
-
-  libinjection_sqli(query, strlen(query), fingerprint);
-
-  libinjection_xss(query, strlen(query));
-
-  free(query);
+  libinjection_xss((const char *)data, size);
 
   return 0;
 }

--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -828,12 +828,9 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
  * wrapper
  *
  *
- * const char* s: is expected to be a null terminated string.
- * size_t len: should represent the length of the string
- *             without the null terminator - strlen(s). 
+ * const char* s: input string, may contain nulls, does not need to be null-terminated.
+ * size_t len: input string length.
  * 
- * Further info:
- *   - https://github.com/client9/libinjection/issues/150
  *
  */
 int libinjection_xss(const char* s, size_t slen)


### PR DESCRIPTION
According to the discussion in #44, it seems that the input strings of `libinjection_xss()` and `libinjection_sqli()` functions might contains NULL characters.

Close #44