### PR TITLE
chore: upload fuzzing artifacts if failure

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -9,11 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     name: fuzzing
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: build
         run: |
           ./autogen.sh
           CC=clang CXX=clang++ ./configure --enable-sanitizers --enable-fuzzers
           make
       - name: fuzz
-        run: ./src/fuzz/fuzzer -max_total_time="${MAX_TOTAL_TIME:-300}" -print_pcs=1 -workers="${FUZZY_WORKERS:-0}" -jobs="${FUZZY_JOBS:-0}" ./src/fuzz/corpus 
+        run: |
+          mkdir out
+          ./src/fuzz/fuzzer \
+            -max_total_time="${MAX_TOTAL_TIME:-300}" \
+            -print_pcs=1 \
+            -workers="${FUZZY_WORKERS:-0}" \
+            -jobs="${FUZZY_JOBS:-0}" \
+            -artifact_prefix=./out ./src/fuzz/corpus 
+
+      - name: Upload Crash
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: artifacts
+          path: ./out


### PR DESCRIPTION
## what

- upload fuzzing artifacts if a failure is detected

## why

- to simplify reproducing the issue