### PR TITLE
fix: set correct length of added argument

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -26,7 +26,7 @@ jobs:
             -artifact_prefix=./out ./src/fuzz/corpus 
 
       - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: artifacts

--- a/src/testdriver.c
+++ b/src/testdriver.c
@@ -50,7 +50,8 @@ size_t print_string(char *buf, size_t len, stoken_t *t) {
 
     /* print closing quote */
     if (t->str_close != '\0') {
-        slen = snprintf(buf + len, sizeof(t->str_close) + 1, "%c", t->str_close);
+        slen =
+            snprintf(buf + len, sizeof(t->str_close) + 1, "%c", t->str_close);
         assert(slen >= 0);
         len += (size_t)slen;
     }

--- a/src/testdriver.c
+++ b/src/testdriver.c
@@ -38,19 +38,19 @@ size_t print_string(char *buf, size_t len, stoken_t *t) {
 
     /* print opening quote */
     if (t->str_open != '\0') {
-        slen = snprintf(buf + len, sizeof(t->str_open), "%c", t->str_open);
+        slen = snprintf(buf + len, sizeof(t->str_open) + 1, "%c", t->str_open);
         assert(slen >= 0);
         len += (size_t)slen;
     }
 
     /* print content */
-    slen = snprintf(buf + len, sizeof(t->val), "%s", t->val);
+    slen = snprintf(buf + len, sizeof(t->val) + 1, "%s", t->val);
     assert(slen >= 0);
     len += (size_t)slen;
 
     /* print closing quote */
     if (t->str_close != '\0') {
-        slen = snprintf(buf + len, sizeof(t->str_close), "%c", t->str_close);
+        slen = snprintf(buf + len, sizeof(t->str_close) + 1, "%c", t->str_close);
         assert(slen >= 0);
         len += (size_t)slen;
     }
@@ -61,12 +61,12 @@ size_t print_string(char *buf, size_t len, stoken_t *t) {
 size_t print_var(char *buf, size_t len, stoken_t *t) {
     int slen;
     if (t->count >= 1) {
-        slen = snprintf(buf + len, sizeof(char), "%c", '@');
+        slen = snprintf(buf + len, sizeof(char) + 1, "%c", '@');
         assert(slen >= 0);
         len += (size_t)slen;
     }
     if (t->count == 2) {
-        slen = snprintf(buf + len, sizeof(char), "%c", '@');
+        slen = snprintf(buf + len, sizeof(char) + 1, "%c", '@');
         assert(slen >= 0);
         len += (size_t)slen;
     }
@@ -119,7 +119,7 @@ size_t print_html5_token(char *buf, size_t len, h5_state_t *hs) {
 size_t print_token(char *buf, size_t len, stoken_t *t) {
     int slen;
 
-    slen = snprintf(buf + len, sizeof(t->type), "%c ", t->type);
+    slen = snprintf(buf + len, sizeof(t->type) + 2, "%c ", t->type);
     assert(slen >= 0);
     len += (size_t)slen;
     switch (t->type) {
@@ -134,7 +134,7 @@ size_t print_token(char *buf, size_t len, stoken_t *t) {
         assert(slen >= 0);
         len += (size_t)slen;
     }
-    slen = snprintf(buf + len, sizeof(char), "%c", '\n');
+    slen = snprintf(buf + len, sizeof(char) + 1, "%c", '\n');
     assert(slen >= 0);
     len += (size_t)slen;
     return len;


### PR DESCRIPTION
This PR fixes the lengths in `snprintf()` functions in `testdriven.c` file, therefore the `make check` will success again.

Also added few GH workflow fixes.