### PR TITLE
chore: fix CI workflow related staff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           cppcheck --std=c89 \
             --enable=all \
             --inline-suppr \
-            --suppress=normalCheckLevelMaxBranches \
             --inconclusive \
             --suppress=variableScope \
             --disable=missingInclude \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           cppcheck --std=c89 \
             --enable=all \
+            --inline-suppr \
+            --suppress=normalCheckLevelMaxBranches \
             --inconclusive \
             --suppress=variableScope \
             --disable=missingInclude \
-            --suppress=unusedFunction:src/fuzz/*.c \
             --quiet \
             --error-exitcode=1 \
             --template='{file}:{line} {id} {severity} {message}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v4.11.0
+      uses: jidicula/clang-format-action@v4.14.0
       with:
         clang-format-version: '16'
         check-path: 'src'
 
   cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: cppcheck
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
             --enable=all \
             --inconclusive \
             --suppress=variableScope \
-            --suppress=missingInclude \
+            --disable=missingInclude \
             --suppress=unusedFunction:src/fuzz/*.c \
             --quiet \
             --error-exitcode=1 \
@@ -40,7 +40,7 @@ jobs:
             .
 
   clang-static:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: clang static check
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         platform: [x32, x64]
         compiler: [gcc, clang]
     steps:
@@ -88,13 +88,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-11]
+        os: [macos-14,macos-15]
         compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v4
 
       - name: Cache brew deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Paths to cache:
           # /usr/local/Homebrew - installation folder of Homebrew

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ src/teststackxss
 
 src/fuzz/fuzzer
 src/fuzz/corpus
+
+src/libinjection_sqli_data.h
+src/sqlparse_data.json

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,9 +4,12 @@ LT_AGE=2
 
 CPPCHECK=@CPPCHECK@
 CPPCHECK_FLAGS=--quiet --enable=all --inconclusive --error-exitcode=2 \
+        --inline-suppr \
+        --suppress=normalCheckLevelMaxBranches \
+        --disable=missingInclude \
         --std=c89 --std=c++11 \
         --suppress=variableScope  \
-        --template '{file}:{line} {severity} {id} {message}'
+        --template='{file}:{line} {severity} {id} {message}'
 
 fingerprints.txt: make_parens.py
 	./make_parens.py < fingerprints.txt > fingerprints2.txt

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -6,7 +6,7 @@
 
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
-int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size) {
+int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size) { // cppcheck-suppress unusedFunction
     char fingerprint[8];
 
     libinjection_sqli((const char *)data, size, fingerprint);

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -6,8 +6,8 @@
 
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
-int LLVMFuzzerTestOneInput(const u_int8_t *data,
-                           size_t size) { // cppcheck-suppress unusedFunction
+int LLVMFuzzerTestOneInput(const u_int8_t *data, // cppcheck-suppress unusedFunction
+                           size_t size) { // cppcheck-suppress unmatchedSuppression
     char fingerprint[8];
 
     libinjection_sqli((const char *)data, size, fingerprint);

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -6,8 +6,9 @@
 
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
-int LLVMFuzzerTestOneInput(const u_int8_t *data, // cppcheck-suppress unusedFunction
-                           size_t size) { // cppcheck-suppress unmatchedSuppression
+int LLVMFuzzerTestOneInput( // cppcheck-suppress unusedFunction
+    const u_int8_t *data,
+    size_t size) {        // cppcheck-suppress unmatchedSuppression
     char fingerprint[8];
 
     libinjection_sqli((const char *)data, size, fingerprint);

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -6,7 +6,8 @@
 
 int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
-int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size) { // cppcheck-suppress unusedFunction
+int LLVMFuzzerTestOneInput(const u_int8_t *data,
+                           size_t size) { // cppcheck-suppress unusedFunction
     char fingerprint[8];
 
     libinjection_sqli((const char *)data, size, fingerprint);

--- a/src/fuzz/fuzzer.c
+++ b/src/fuzz/fuzzer.c
@@ -8,7 +8,7 @@ int LLVMFuzzerTestOneInput(const u_int8_t *data, size_t size);
 
 int LLVMFuzzerTestOneInput( // cppcheck-suppress unusedFunction
     const u_int8_t *data,
-    size_t size) {        // cppcheck-suppress unmatchedSuppression
+    size_t size) { // cppcheck-suppress unmatchedSuppression
     char fingerprint[8];
 
     libinjection_sqli((const char *)data, size, fingerprint);

--- a/src/html5_cli.c
+++ b/src/html5_cli.c
@@ -130,7 +130,7 @@ const char *h5_type_to_string(enum html5_type x) {
     }
 }
 
-void print_html5_token(h5_state_t *hs) {
+void print_html5_token(h5_state_t *hs) { // cppcheck-suppress constParameterPointer
     char *tmp = (char *)malloc(hs->token_len + 1);
     memcpy(tmp, hs->token_start, hs->token_len);
     /* TODO.. encode to be printable */

--- a/src/html5_cli.c
+++ b/src/html5_cli.c
@@ -130,7 +130,8 @@ const char *h5_type_to_string(enum html5_type x) {
     }
 }
 
-void print_html5_token(h5_state_t *hs) { // cppcheck-suppress constParameterPointer
+void print_html5_token(
+    h5_state_t *hs) { // cppcheck-suppress constParameterPointer
     char *tmp = (char *)malloc(hs->token_len + 1);
     memcpy(tmp, hs->token_start, hs->token_len);
     /* TODO.. encode to be printable */

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -343,7 +343,7 @@ static int st_is_unary_op(const stoken_t *st) {
  *
  */
 
-static size_t parse_white(struct libinjection_sqli_state *sf) {
+static size_t parse_white(struct libinjection_sqli_state *sf) { // cppcheck-suppress constParameterCallback
     return sf->pos + 1;
 }
 
@@ -1203,7 +1203,7 @@ int libinjection_sqli_tokenize(struct libinjection_sqli_state *sf) {
     }
 
     st_clear(current);
-    sf->current = current;
+    sf->current = current; // cppcheck-suppress redundantAssignment
 
     /*
      * if we are at beginning of string
@@ -1299,7 +1299,7 @@ void libinjection_sqli_callback(struct libinjection_sqli_state *sf,
  *
  */
 static int syntax_merge_words(struct libinjection_sqli_state *sf, stoken_t *a,
-                              stoken_t *b) {
+                              stoken_t *b) { // cppcheck-suppress constParameterPointer
     size_t sz1;
     size_t sz2;
     size_t sz3;
@@ -2221,7 +2221,7 @@ int libinjection_sqli_not_whitelist(struct libinjection_sqli_state *sql_state) {
  *
  *
  */
-static int reparse_as_mysql(struct libinjection_sqli_state *sql_state) {
+static int reparse_as_mysql(struct libinjection_sqli_state *sql_state) { // cppcheck-suppress constParameterPointer
     return sql_state->stats_comment_ddx || sql_state->stats_comment_hash;
 }
 

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -1204,7 +1204,8 @@ int libinjection_sqli_tokenize(struct libinjection_sqli_state *sf) {
     }
 
     st_clear(current);
-    sf->current = current; // cppcheck-suppress[redundantAssignment,unmatchedSuppression]
+    sf->current =
+        current; // cppcheck-suppress[redundantAssignment,unmatchedSuppression]
 
     /*
      * if we are at beginning of string

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -90,6 +90,9 @@ typedef enum {
     TYPE_BACKSLASH = (int)'\\'
 } sqli_token_types;
 
+// prototype for is_backslash_escaped()
+static int is_backslash_escaped(const char *end, const char *start);
+
 /**
  * Initializes parsing state
  *

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -1204,7 +1204,7 @@ int libinjection_sqli_tokenize(struct libinjection_sqli_state *sf) {
     }
 
     st_clear(current);
-    sf->current = current; // cppcheck-suppress redundantAssignment
+    sf->current = current; // cppcheck-suppress[redundantAssignment,unmatchedSuppression]
 
     /*
      * if we are at beginning of string

--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -343,7 +343,8 @@ static int st_is_unary_op(const stoken_t *st) {
  *
  */
 
-static size_t parse_white(struct libinjection_sqli_state *sf) { // cppcheck-suppress constParameterCallback
+static size_t parse_white(struct libinjection_sqli_state
+                              *sf) { // cppcheck-suppress constParameterCallback
     return sf->pos + 1;
 }
 
@@ -1298,8 +1299,9 @@ void libinjection_sqli_callback(struct libinjection_sqli_state *sf,
  *  This is just:  multikeywords[token.value + ' ' + token2.value]
  *
  */
-static int syntax_merge_words(struct libinjection_sqli_state *sf, stoken_t *a,
-                              stoken_t *b) { // cppcheck-suppress constParameterPointer
+static int
+syntax_merge_words(struct libinjection_sqli_state *sf, stoken_t *a,
+                   stoken_t *b) { // cppcheck-suppress constParameterPointer
     size_t sz1;
     size_t sz2;
     size_t sz3;
@@ -2221,7 +2223,9 @@ int libinjection_sqli_not_whitelist(struct libinjection_sqli_state *sql_state) {
  *
  *
  */
-static int reparse_as_mysql(struct libinjection_sqli_state *sql_state) { // cppcheck-suppress constParameterPointer
+static int
+reparse_as_mysql(struct libinjection_sqli_state
+                     *sql_state) { // cppcheck-suppress constParameterPointer
     return sql_state->stats_comment_ddx || sql_state->stats_comment_hash;
 }
 

--- a/src/libinjection_sqli.h
+++ b/src/libinjection_sqli.h
@@ -35,7 +35,7 @@ enum lookup_type {
     LOOKUP_FINGERPRINT = 4
 };
 
-struct libinjection_sqli_token {
+struct libinjection_sqli_token { // cppcheck-suppress syntaxError
 #ifdef SWIG
 %immutable;
 #endif

--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -535,26 +535,30 @@ static const char *BLACKTAG[] = {
     NULL};
 
 static int cstrcasecmp_with_null(const char *a, const char *b, size_t n) {
+    unsigned int ai = 0, bi = 0;
     char ca;
     char cb;
     /* printf("Comparing to %s %.*s\n", a, (int)n, b); */
     while (n-- > 0) {
-        cb = *b++;
-        if (cb == '\0')
+        cb = b[bi++];
+        if (cb == '\0') {
             continue;
+        }
 
-        ca = *a++;
+        ca = a[ai++];
 
         if (cb >= 'a' && cb <= 'z') {
             cb -= 0x20;
         }
+
         /* printf("Comparing %c vs %c with %d left\n", ca, cb, (int)n); */
         if (ca != cb) {
             return 1;
         }
     }
+    ca = a[ai++];
 
-    if (*a == 0) {
+    if (ca == '\0') {
         /* printf(" MATCH \n"); */
         return 0;
     } else {

--- a/src/sqli_cli.c
+++ b/src/sqli_cli.c
@@ -20,7 +20,7 @@ void print_var(stoken_t *t);
 void print_token(stoken_t *t);
 void usage(void);
 
-void print_string(stoken_t *t) {
+void print_string(stoken_t *t) { // cppcheck-suppress constParameterPointer
     /* print opening quote */
     if (t->str_open != '\0') {
         printf("%c", t->str_open);

--- a/src/testdriver.c
+++ b/src/testdriver.c
@@ -33,7 +33,8 @@ size_t modp_rtrim(char *str, size_t len) {
     return len;
 }
 
-size_t print_string(char *buf, size_t len, stoken_t *t) { // cppcheck-suppress constParameterPointer
+size_t print_string(char *buf, size_t len,
+                    stoken_t *t) { // cppcheck-suppress constParameterPointer
     int slen = 0;
 
     /* print opening quote */
@@ -102,7 +103,9 @@ const char *h5_type_to_string(enum html5_type x) {
     return "";
 }
 
-size_t print_html5_token(char *buf, size_t len, h5_state_t *hs) { // cppcheck-suppress constParameterPointer
+size_t
+print_html5_token(char *buf, size_t len,
+                  h5_state_t *hs) { // cppcheck-suppress constParameterPointer
     int slen;
     char *tmp = (char *)malloc(hs->token_len + 1);
 

--- a/src/testdriver.c
+++ b/src/testdriver.c
@@ -33,7 +33,7 @@ size_t modp_rtrim(char *str, size_t len) {
     return len;
 }
 
-size_t print_string(char *buf, size_t len, stoken_t *t) {
+size_t print_string(char *buf, size_t len, stoken_t *t) { // cppcheck-suppress constParameterPointer
     int slen = 0;
 
     /* print opening quote */
@@ -102,7 +102,7 @@ const char *h5_type_to_string(enum html5_type x) {
     return "";
 }
 
-size_t print_html5_token(char *buf, size_t len, h5_state_t *hs) {
+size_t print_html5_token(char *buf, size_t len, h5_state_t *hs) { // cppcheck-suppress constParameterPointer
     int slen;
     char *tmp = (char *)malloc(hs->token_len + 1);
 


### PR DESCRIPTION
This PR is a set of commits:
* update action versions and runners for macos (@fzipi)
* add function prototype in `src/libinjection_sqli.c` - fixes build errors
* fix `cppcheck` issues:
  * add inline suppression's - at the moment it would be too much work to fix all `cppcheck` warnings
* fix [fuzzing](https://github.com/libinjection/libinjection/blob/main/.github/workflows/fuzzing.yml) issues
  * there were couple of failed tests, eg like [this](https://github.com/airween/libinjection/actions/runs/13574705287/job/37947997410); we weren't able to reproduce it locally, the modification is based on `clang` compiler's warnings and the `fuzzy` test's output
