### PR TITLE
chore: buffer overflow fix

### DIFF
--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -672,12 +672,12 @@ static attribute_t is_black_attr(const char *s, size_t len) {
             size_t s_without_on_len = len - 2; // temporary length variable
             while (black->name != NULL) {
                 size_t black_name_len = strlen(black->name);
-                size_t max_len =
-                    (s_without_on_len < black_name_len)
-                        ? s_without_on_len
-                        : black_name_len;  // determine the maximum length to compare
-                if (cstrcasecmp_with_null(black->name, s_without_on,
-                                          max_len) == 0) {
+                // determine the maximum length to compare
+                size_t max_len = (s_without_on_len < black_name_len)
+                                     ? s_without_on_len
+                                     : black_name_len;
+                if (cstrcasecmp_with_null(black->name, s_without_on, max_len) ==
+                    0) {
                     /* printf("Got banned attribute name %s\n", black->name); */
                     return black->atype;
                 }


### PR DESCRIPTION
This PR tries to fix the error which comes during fuzzy [test](https://github.com/libinjection/libinjection/actions/runs/18632149463/job/53118367455#step:4:1622).

I analyzed the code and unfortunately there is a possible problem but not where the CI action shows ([here](https://github.com/libinjection/libinjection/blob/fe05a23de615d17d104803b968382fad3ae9cded/src/libinjection_xss.c#L543)), but the caller function [here](https://github.com/libinjection/libinjection/blob/fe05a23de615d17d104803b968382fad3ae9cded/src/libinjection_xss.c#L673-L674).

The function `is_black_attr()` calls the mentioned function but the 3rd argument is not the length of 2nd argument (which controls the cycle in `cstrcasecmp_with_null()`, but with the length of 1st argument. If the 2nd argument's length is less than the 1st argument length, then the code in the mentioned [line](https://github.com/libinjection/libinjection/blob/fe05a23de615d17d104803b968382fad3ae9cded/src/libinjection_xss.c#L543):
```C
        cb = b[bi++];
```
wants to read from a memory area which does not belong to the 2nd argument.

I wasn't able to reproduce that error everywhere, so I hope this PR fixes the issue (the problem is triggered only in PR CI actions).