### PR TITLE
docs: add Ruby external port to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ SQL / SQLI tokenizer parser analyzer. For
 * [Lua](/lua)
 * [Java](https://github.com/jeonglee/Libinjection) (external port)
 * [LuaJIT/FFI](https://github.com/p0pr0ck5/lua-ffi-libinjection) (external port)
+* [Ruby](https://github.com/roman-haidarov/rack-libinjection) (external port)
 
 Simple example:
 


### PR DESCRIPTION
Hi,

I maintain rack-libinjection, a native Ruby binding plus Rack
middleware for libinjection v4.0.0, published as a Ruby gem.

This PR adds it to the README as an external Ruby port, following
the existing Java and LuaJIT/FFI external port entries.

- Repo: https://github.com/roman-haidarov/rack-libinjection
- Gem:  https://rubygems.org/gems/rack-libinjection

Happy to adjust the wording.