### PR TITLE
docs: explain the parse contexts and why length is not the axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ The filler need not be meaningful. `flush logs`, `reset query` and `help help`
 all work the same way. This is the limitation behind issues such as #26 and #61,
 and it is not something a new fingerprint can generally close.
 
+**Length is not the axis.** An input is parsed in up to five contexts, stopping
+at the first one whose fingerprint matches:
+
+```
+FLAG_QUOTE_NONE   | FLAG_SQL_ANSI     always
+FLAG_QUOTE_NONE   | FLAG_SQL_MYSQL    only if the input used a # or /*! comment
+FLAG_QUOTE_SINGLE | FLAG_SQL_ANSI     only if the input contains '
+FLAG_QUOTE_SINGLE | FLAG_SQL_MYSQL    only if it contains ' and used # or /*!
+FLAG_QUOTE_DOUBLE | FLAG_SQL_MYSQL    only if the input contains "
+```
+
+The quoted contexts re-read the input as though it began inside a string
+literal, so everything before the first quote becomes a single token, and a long
+prefix costs one slot rather than many:
+
+```
+plain-asni :  nnnnn   <- 1760 characters of filler exhausts the window
+single-ansi:  s&1c    <- same input, the filler collapses to one `s`, payload intact
+```
+
+A 5 KB input carrying a quoted payload is detected; the 58-byte example above is
+not. Note that the example has no quote in it at all, so only the two unquoted
+contexts ever run and no prefix collapsing is available to it.
+
+Do not gate calls to libinjection on input length. Doing so skips detections that
+would otherwise be made, and does not skip the inputs that are actually missed.
+
 > [!WARNING]
 > **Do not raise `LIBINJECTION_SQLI_MAX_TOKENS`.** It is not a tuning knob. The
 > fingerprint database is built from fingerprints that are at most five folded tokens long, and several internal buffers assume that size (for example `char fp2[8]` in `src/libinjection_sqli.c` and `fingerprint[8]` / `tokenvec[8]` in `src/libinjection_sqli.h`). Raising the value makes detection *worse* and then unsafe:


### PR DESCRIPTION
Follow-up to #86. That PR documented the five-token fold window, which invites a conclusion that is false: that long input evades detection, and that a caller could therefore skip libinjection on large values.

Measured, the opposite holds:

| input | length | detected |
|---|---|---|
| `' or 1=1--` followed by 5 KB of filler | 5291 | yes |
| 5 KB of filler followed by `' or 1=1--` | 5290 | yes |
| `0); a b; set @q=0x41; prepare stmt from @q; execute stmt;#` | **58** | **no** |

## What this adds

The reason is the parse contexts, which were not documented. An input is parsed in up to five, stopping at the first fingerprint match, and three of the five are conditional:

```
FLAG_QUOTE_NONE   | FLAG_SQL_ANSI     always
FLAG_QUOTE_NONE   | FLAG_SQL_MYSQL    only if the input used a # or /*! comment
FLAG_QUOTE_SINGLE | FLAG_SQL_ANSI     only if the input contains '
FLAG_QUOTE_SINGLE | FLAG_SQL_MYSQL    only if it contains ' and used # or /*!
FLAG_QUOTE_DOUBLE | FLAG_SQL_MYSQL    only if the input contains "
```

In the quoted contexts the input is re-read as though it began inside a string literal, so everything before the first quote becomes one token:

```
plain-asni :  nnnnn   <- 1760 characters of filler exhausts the window
single-ansi:  s&1c    <- same input, filler collapses to one `s`, payload intact
```

That is why length costs nothing when a quote is present. It also explains the counterexample: the 58-byte payload contains no quote at all, so only the two unquoted contexts run and no prefix collapsing is available to it.

The section closes by saying plainly not to gate calls on input length, since doing so skips detections that would otherwise be made while not skipping the inputs that are actually missed.

## Verification

Behaviour confirmed with `src/fptool` on this branch:

```
$ ./src/fptool "<1760 chars of filler>' or 1=1--"
plain-asni	nnnnn	false
single-ansi	s&1c	true

$ ./src/fptool "0); a b; set @q=0x41; prepare stmt from @q; execute stmt;#"
plain-asni	1);nn	false
plain-mysql	1);nn	false
```

Context list and guards read from `src/libinjection_sqli.c:2273-2325`; the MySQL conditions come from `reparse_as_mysql()` at line 2243, which is `stats_comment_ddx || stats_comment_hash`.

Docs only — no code, no test changes.

## ai disclosure

- **tools used**: Claude (Opus 5), via Claude Code
- **assisted with**: the measurements, reading the context-selection logic, and drafting this section
- **review performed**: three drafting errors were caught by reading the source rather than assuming — the contexts are first-match-wins rather than best-match, the quoted contexts are guarded by `memchr` for the relevant quote character, and the MySQL contexts are guarded by `reparse_as_mysql()` rather than always running; the table reflects the corrected behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
